### PR TITLE
fixed incorrect method signature

### DIFF
--- a/src/amqp-pubsub.ts
+++ b/src/amqp-pubsub.ts
@@ -36,13 +36,13 @@ export class AmqpPubSub implements PubSubEngine {
 
   }
 
-  publish(trigger: string, payload: any): boolean {
+  public publish(trigger: string, payload: any): Promise<void> {
     // As PubSubEngine publish interface is sync, spin up a promise asynchronously, and just return true
     // All implementations are built this way and there seems to be no workaround without changing
     // graphql-subscription, so we must (regardless of implementation) make sure that system doesn't
     // depend on order of the events.
     this.producer.publish(new QueueConfig(trigger), payload);
-    return true;
+    return Promise.resolve()
   }
 
   public subscribe(trigger: string, onMessage: Function, options?: Object): Promise<number> {


### PR DESCRIPTION
`AmqpPubSub` implements `PubSubEngine` from the `graphql-subscriptions` package, which has a public method called `publish` with a return signature of `Promise<void>`:
https://github.com/apollographql/graphql-subscriptions/blob/master/src/pubsub.ts#L20

`AmqpPubSub` as of right now has a `publish` method with a return signature of `boolean`, and so `AmqpPubSub` does not implement `PubSubEngine` correctly. As of right now this project will not compile with this incorrect return signature using tsc, and breaks all typescript projects that depend upon it including the typescript templates for MAANA-Q services.